### PR TITLE
Integrate readline for REPL via rustyline crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,12 @@ some additions:
 
     - Example: `$ ./bf ',[.[-],]' < README.md`
 
+
 ## TODOs
 - [ ] Accept and ignore non-command characters instead of failing (comments)
-- [ ] Integrate `readline` for REPL input
+- [x] Integrate `readline` for REPL input
 - [ ] Write docstrings
 - [ ] Support running from file with `-f` and `--file`
 - [ ] Add `-h`/`--help` usage flag
 - [ ] Add `-v`/`--verbose` flag to print extra information (like exit message)
+- [ ] Implement full unit test coverage

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,45 +1,47 @@
-use std::io::Write;
+extern crate rustyline;
+
+use rustyline::{Editor, error::ReadlineError};
 
 use crate::token::Token;
 use crate::interpreter;
 
+static HISTORY_FILE: &'static str = ".bf_history";
+
 pub fn run(state: &mut interpreter::State) {
-    // don't quite have this working yet
-    // TODO: de-uglify -- this needs to be thought through
-    let prompt: &'static str = "$ ";
-    println!(
-"You have entered an interactive session. All regular commands are available.
-Enter 'q' to exit the session and resume program execution.");
-    let mut buffer = String::new();
+    let mut rl = Editor::<()>::new();
+
+    println!("\
+You have entered an interactive session. All regular commands are available.
+
+Commands:
+    'c' : Continue execution at the command following this breakpoint
+    'q' : Exit interpreter
+");
+
     'repl: loop {
-        print!("{}", prompt);
-        std::io::stdout().flush().unwrap();
-        buffer.retain(|_| false); // empty buffer
-        match std::io::stdin().read_line(&mut buffer) {
-            Ok(_) => {
-                let mut new_program: Vec<Token> = Vec::new();
-                let prev_program_ptr = state.program_ptr;
-                state.program_ptr = 0;
-                for c in buffer.trim().chars() {
-                    if c == 'q' {
-                        for command in &new_program {
-                            interpreter::run_command(state, &command, &new_program);
-                        }
-                        state.program_ptr = prev_program_ptr;
-                        break 'repl;
-                    } else {
-                        match Token::decode(c) {
-                            Ok(command) => new_program.push(command),
-                            Err(err) => eprintln!("{}", err),
-                        };
-                    };
-                };
-                for command in &new_program {
-                    interpreter::run_command(state, &command, &new_program);
-                }
-                state.program_ptr = prev_program_ptr;
+        let input_line = rl.readline("bf $ ");
+        match input_line {
+            Ok(line) if line == "q" => {
+                state.status = interpreter::ExecutionStatus::Terminated;
+                break 'repl;
             },
-            Err(_) => println!("invalid input"),
+            Ok(line) if line == "c" => break 'repl,
+            Ok(line) => {
+                rl.add_history_entry(line.as_str());
+                let new_program = interpreter::parse_program(line.as_str());
+                match new_program {
+                    Ok(program) => {
+                        let prev_program_ptr = state.program_ptr;
+                        state.program_ptr = 0;
+                        interpreter::run_program(state, &program);
+                        state.program_ptr = prev_program_ptr;
+                    },
+                    Err(e) => println!("{:?}", e),
+                }
+            },
+            Err(e) => println!("{:?}", e),
         }
     }
+
+    state.program_ptr += 1;
 }


### PR DESCRIPTION
This PR encompasses significant changes to the REPL UX: line history (and other niceties that aren't typically thought about) is supported via `readline`!

First foray into 3rd party crate usage. Extremely smooth process: update `Cargo.toml` and the next `cargo build` handles the rest. The most surprising thing is how much cleaner the REPL implementation became after integrating this library — most of the complexity about shuttling data in from stdin is handled by rustyline's hassle-free API.