### PR TITLE
Proper command line argument options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = "2.33.0"
 rustyline = "5.0.4"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Brainfuck Interpreter
+# BrainF\*ck Interpreter
 The secondary purpose of this project is to implement an interpreter for the
-[Brainfuck programming language](https://en.wikipedia.org/wiki/Brainfuck) with
+[BrainF\*ck programming language](https://en.wikipedia.org/wiki/Brainfuck) with
 a few extensions. The primary purpose is to learn Rust.
 
 
@@ -23,7 +23,7 @@ This implementation follows the
 [Wikipedia standard](https://en.wikipedia.org/wiki/Brainfuck#Commands) with
 some additions:
 - `?`: Dump the internal program execution state to stderr
-- `!`: Breakpoint to enter into a Brainfuck REPL
+- `!`: Breakpoint to enter into a BrainF\*ck REPL
 
 
 
@@ -39,6 +39,7 @@ some additions:
     - Expected options like `--help`
 - Reasonable performance and resource usage (nothing dumb)
 - Non-negligible test coverage
+- No compiler warnings
 
 
 
@@ -81,3 +82,4 @@ some additions:
 - [ ] Add `-h`/`--help` usage flag
 - [ ] Add `-v`/`--verbose` flag to print extra information (like exit message)
 - [ ] Implement full unit test coverage
+- [ ] Apply `rustfmt` formatting

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ some additions:
 - [ ] Accept and ignore non-command characters instead of failing (comments)
 - [x] Integrate `readline` for REPL input
 - [ ] Write docstrings
-- [ ] Support running from file with `-f` and `--file`
-- [ ] Add `-h`/`--help` usage flag
-- [ ] Add `-v`/`--verbose` flag to print extra information (like exit message)
+- [x] Support running from file with `-f` and `--file`
+- [x] Add `-h`/`--help` usage flag
+- [x] Add `-v`/`--verbose` flag to print extra information (like exit message)
 - [ ] Implement full unit test coverage
 - [ ] Apply `rustfmt` formatting

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,6 @@
-use std::env;
+extern crate clap;
+
+use clap::{Arg, App, ArgMatches};
 
 mod token;
 mod interpreter;
@@ -7,35 +9,67 @@ mod repl;
 #[cfg(test)]
 mod test;
 
+static PROGRAM_ARG: &'static str = "program";
+static VERBOSE_ARG: &'static str = "verbose";
+static FILENAME_ARG: &'static str = "filename";
+
+// explicitly specify 'static lifetime
+fn get_command_line_args() -> ArgMatches<'static> {
+    App::new("bf")
+        .version("0.1")
+        .about("BrainF*ck language interpreter")
+        .arg(
+            Arg::with_name(PROGRAM_ARG)
+                .help("Program to execute")
+                .required(true)
+                .conflicts_with(FILENAME_ARG)
+                .index(1))
+        .arg(
+            Arg::with_name(VERBOSE_ARG)
+                .short("v")
+                .long("verbose")
+                .help("Toggle high verbosity"))
+        .arg(
+            Arg::with_name(FILENAME_ARG)
+                .short("f")
+                .long("filename")
+                .takes_value(true)
+                .value_name("FILENAME")
+                .conflicts_with(PROGRAM_ARG)
+                .help("Program file to execute"))
+        .get_matches()
+}
+
 fn main() {
-    let err_str: &'static str = "usage: bf <program>";
-    let args: Vec<String> = env::args().collect();
-    // assert_eq!(args.len(), 2);
-    std::process::exit(match &args[..] {
-        [_, program] => {
-            let state = interpreter::run(program);
-            match state.status {
-                interpreter::ExecutionStatus::Terminated => {
-                    eprintln!("bf interpreter terminated: 0");
-                    0
-                },
-                interpreter::ExecutionStatus::Error(err) => {
-                    eprintln!("bf interpreter exited with error: {}", err);
-                    1
-                },
-                _ => {
-                    eprintln!("{:?}", state);
-                    1
-                },
-            }
+    let opts = get_command_line_args();
+
+    let program_string: String = match (opts.value_of(PROGRAM_ARG), opts.value_of(FILENAME_ARG)) {
+        (Some(s), None) => s.to_string(),
+        (None, Some(filename)) => match std::fs::read_to_string(filename) {
+            Ok(contents) => contents,
+            Err(e) => {
+                eprintln!("bf: file '{}' could not be read ({})", filename, e);
+                std::process::exit(1);
+            },
         },
-        [_] => {
-            eprintln!("{}", err_str);
+        // final arm should never be reached due to mutual `conflicts_with`
+        _ => panic!("bf: argument error"),
+    };
+
+    let program_state_after_execution = interpreter::run(program_string.as_str());
+    let retcode: i32 = match program_state_after_execution.status {
+        interpreter::ExecutionStatus::Terminated => {
+            if opts.is_present(VERBOSE_ARG) {
+                eprintln!("bf: terminated without errors");
+            };
             0
         },
-        _ => {
-            eprintln!("{}", err_str);
-            0
+        interpreter::ExecutionStatus::Error(err) => {
+            eprintln!("bf: exited with error: {}", err);
+            1
         },
-    });
+        _ => panic!("bf: internal error"),
+    };
+
+    std::process::exit(retcode);
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,11 +1,8 @@
 extern crate rustyline;
 
-use rustyline::{Editor, error::ReadlineError};
+use rustyline::Editor;
 
-use crate::token::Token;
 use crate::interpreter;
-
-static HISTORY_FILE: &'static str = ".bf_history";
 
 pub fn run(state: &mut interpreter::State) {
     let mut rl = Editor::<()>::new();


### PR DESCRIPTION
Another 3rd party crate, this time to handle command line options. [Clap](https://github.com/clap-rs/clap) seems to be the standard here and integrating it was not painful. A number of patterns are supported for argument declaration and I went with the most verbose, most Rust-based option available. It seemed right for this project to stray away from YAML declaration, string-based declaration, and the unholy macro abomination that is the first example in clap's README.

Anyway, here's what to expect:
```
$ ./bf --help
bf 0.1
BrainF*ck language interpreter

USAGE:
    bf [FLAGS] [OPTIONS] <program>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information
    -v, --verbose    Toggle high verbosity

OPTIONS:
    -f, --filename <FILENAME>    Program file to execute

ARGS:
    <program>    Program to execute
```