### PR TITLE
Sufficiently general IoCtx implementation to support binary, testing, library use cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 **/*.rs.bk
 Cargo.lock
 
+# vim tmp files
 *.swo
 *.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,6 @@ after_success: |
   make install DESTDIR=../../kcov-build &&
   cd ../.. &&
   rm -rf kcov-master &&
-  for file in target/debug/bfi-* target/debug/deps/integration-*; do [ -x "${file}" ] || continue; mkdir -p "target/cov/$(basename $file)"; ./kcov-build/usr/local/bin/kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done &&
+  for file in target/debug/bfi-* target/debug/deps/executable-*; do [ -x "${file}" ] || continue; mkdir -p "target/cov/$(basename $file)"; ./kcov-build/usr/local/bin/kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done &&
   bash <(curl -s https://codecov.io/bash) &&
   echo "Uploaded code coverage"

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ $ ./target/release/bfi <program>
     - Read program input from stdin
     - Proper exit code setting
     - Expected options like `--help`
+    - Expected behavior on SIGINT, EOF, SIGTERM, etc.
 - Reasonable performance and resource usage (nothing dumb)
 - Non-negligible test coverage
 - No compiler warnings

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -214,7 +214,7 @@ impl<'a> ExecutionContext<'a> {
 mod test {
     use super::*;
     use std::cell::RefCell;
-    use crate::ioctx;
+    use crate::ioctx::{InMemoryIoCtx, IoCtx};
 
     #[test]
     fn test_pointer_increment() {
@@ -240,12 +240,13 @@ mod test {
 
     #[test]
     fn test_input_output() {
-        let ictx = RefCell::new(Box::new(ioctx::MockIoCtx::default()) as Box<dyn ioctx::IoCtx>);
+        let ictx = RefCell::new(Box::new(InMemoryIoCtx::default()) as Box<dyn IoCtx>);
+        let mut ictx_ref = ictx.borrow_mut();
         let val = b"value";
-        (*ictx.borrow_mut()).write_input(val).unwrap();
-        let status = ExecutionContext::new(ictx.borrow_mut(), ",[.[-],]").execute();
+        ictx_ref.write_input(val).unwrap();
+        let status = ExecutionContext::new(ictx_ref, ",[.[-],]").execute();
         let mut buf = [0u8; 5];
-        let output = (*ictx.borrow_mut()).read_output(&mut buf);
+        let output = ictx.borrow_mut().read_output(&mut buf);
         assert_eq!(output.unwrap(), 5usize);
         assert_eq!(val, &buf);
         assert_eq!(status, ExecutionStatus::<String>::Terminated);

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,9 +1,11 @@
+use std::cell::RefMut;
 use std::default::Default;
 use std::fmt::{self, Debug};
 
 use crate::ioctx;
 use crate::repl;
 use crate::token::Token;
+
 
 #[derive(Debug, Copy, Clone)]
 pub enum ExecutionStatus<T> {
@@ -14,9 +16,11 @@ pub enum ExecutionStatus<T> {
     InternalError(T),
 }
 
-pub struct ExecutionContext {
-    status: ExecutionStatus<String>,
-    ctx: Box<dyn ioctx::RW>,
+
+pub struct ExecutionContext<'a> {
+    pub status: ExecutionStatus<String>,
+    // ctx: Option<RefMut<'a, Box<dyn ioctx::RW>>>,
+    ctx: RefMut<'a, Box<dyn ioctx::RW>>,
     data: Vec<u8>,
     data_ptr: usize,
     program: Vec<Token>,
@@ -24,7 +28,8 @@ pub struct ExecutionContext {
     loop_stack: Vec<usize>,
 }
 
-impl Debug for ExecutionContext {
+
+impl<'a> Debug for ExecutionContext<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -34,11 +39,13 @@ impl Debug for ExecutionContext {
     }
 }
 
-impl Default for ExecutionContext {
+
+/*
+impl<'a> Default for ExecutionContext<'a> {
     fn default() -> Self {
         ExecutionContext {
             status: ExecutionStatus::NotStarted,
-            ctx: Box::new(ioctx::StdIOContext::new()),
+            // ctx: None,
             data: vec![0],
             data_ptr: 0,
             program: vec![],
@@ -47,13 +54,24 @@ impl Default for ExecutionContext {
         }
     }
 }
+*/
 
-impl ExecutionContext {
-    pub fn new(ictx: Box<dyn ioctx::RW>, program: &str) -> Self {
+
+impl<'a> ExecutionContext<'a> {
+    pub fn new(ictx: RefMut<'a, Box<dyn ioctx::RW>>, program: &str) -> Self {
         ExecutionContext {
+            /*
             ctx: ictx,
             program: Token::parse_str(program),
             ..ExecutionContext::default()
+            */
+            status: ExecutionStatus::NotStarted,
+            ctx: ictx,
+            data: vec![0],
+            data_ptr: 0,
+            program: Token::parse_str(program),
+            program_ptr: 0,
+            loop_stack: vec![],
         }
     }
 
@@ -148,10 +166,15 @@ impl ExecutionContext {
     fn put_character(&mut self) {
         // TODO: actually handle Result here
         (*self.ctx).write_all(&self.data[self.data_ptr..=self.data_ptr]).unwrap();
+        /*
+        self.ctx.and_then(|ictx| {
+            (*ictx).write_all(&self.data[self.data_ptr..=self.data_ptr]).unwrap();
+            Some(())
+        });
+        */
     }
 
     fn get_character(&mut self) {
-        // let mut buffer: [u8; 1024] = [0; 1024];
         let mut buffer: [u8; 1] = [0; 1];
         match (*self.ctx).read(&mut buffer[..]) {
             Ok(n) if n == 1 => self.data[self.data_ptr] = buffer[0],
@@ -159,6 +182,17 @@ impl ExecutionContext {
             Ok(_) => {}, // self.status = ExecutionStatus::Terminated,
             Err(e) => self.status = ExecutionStatus::InternalError(format!("{}", e).to_string()),
         }
+        /*
+        if let Some(mut ictx) = &self.ctx {
+            let mut buffer: [u8; 1] = [0; 1];
+            match (*ictx).read(&mut buffer[..]) {
+                Ok(n) if n == 1 => self.data[self.data_ptr] = buffer[0],
+                // TODO: why is reading nothing acceptable?
+                Ok(_) => {}, // self.status = ExecutionStatus::Terminated,
+                Err(e) => self.status = ExecutionStatus::InternalError(format!("{}", e).to_string()),
+            }
+        }
+        */
     }
 
     fn find_loop_end(ptr: usize, program: &[Token]) -> Result<usize, ()> {
@@ -201,11 +235,11 @@ impl ExecutionContext {
 }
 
 
-
 #[cfg(test)]
 mod test {
     use super::*;
 
+    /*
     #[test]
     fn test_pointer_increment() {
         let mut ectx = ExecutionContext::default();
@@ -227,4 +261,5 @@ mod test {
         let program = vec![Token::PtrInc, Token::LoopEnd];
         assert_eq!(Ok(1), ExecutionContext::find_loop_end(0, &program));
     }
+    */
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -8,7 +8,7 @@ use crate::repl;
 use crate::token::Token;
 
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum ExecutionStatus<T> {
     NotStarted,
     InProgress,
@@ -240,12 +240,14 @@ mod test {
 
     #[test]
     fn test_input_output() {
-        let ictx = RefCell::new(Box::new(ioctx::MockIoCtx::default()) as Box<ioctx::IoCtx>);
+        let ictx = RefCell::new(Box::new(ioctx::MockIoCtx::default()) as Box<dyn ioctx::IoCtx>);
         let val = b"value";
-        (*ictx.borrow_mut()).write_input(val);
-        let _status = ExecutionContext::new(ictx.borrow_mut(), ",[.[-],]").execute();
+        (*ictx.borrow_mut()).write_input(val).unwrap();
+        let status = ExecutionContext::new(ictx.borrow_mut(), ",[.[-],]").execute();
         let mut buf = [0u8; 5];
         let output = (*ictx.borrow_mut()).read_output(&mut buf);
+        assert_eq!(output.unwrap(), 5usize);
         assert_eq!(val, &buf);
+        assert_eq!(status, ExecutionStatus::<String>::Terminated);
     }
 }

--- a/src/ioctx.rs
+++ b/src/ioctx.rs
@@ -4,37 +4,23 @@ use std::default::Default;
 
 pub trait IoCtx {
     fn read_input(&mut self, buf: &mut [u8]) -> io::Result<usize>;
-    fn write_input(&mut self, buf: &[u8]) -> io::Result<usize> {
+    fn write_input(&mut self, _: &[u8]) -> io::Result<usize> {
         panic!("`write_input` unsupported for `StdIoCtx`");
     }
     fn write_output(&mut self, buf: &[u8]) -> io::Result<usize>;
-    fn read_output(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+    fn read_output(&mut self, _: &mut [u8]) -> io::Result<usize> {
         panic!("`read_output` unsupported for `StdIoCtx`");
     }
     fn flush_output(&mut self) -> io::Result<()>;
 }
 
-// This workaround type wrapper for a generic T is directly in response to the error message:
-// = note: only traits defined in the current crate can be implemented for a type parameter
-// Solution taken from the error index: https://doc.rust-lang.org/error-index.html#E0210
-// struct IoCtxType<T>(T);
-
 impl Read for dyn IoCtx {
-// impl<T> Read for IoCtxType<T> where T: IoCtx {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.read_input(buf)
-    }
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> { self.read_input(buf) }
 }
 
 impl Write for dyn IoCtx {
-// impl<T> Write for IoCtxType<T> where T: IoCtx {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.write_output(buf)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.flush_output()
-    }
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> { self.write_output(buf) }
+    fn flush(&mut self) -> io::Result<()> { self.flush_output() }
 }
 
 

--- a/src/ioctx.rs
+++ b/src/ioctx.rs
@@ -1,20 +1,51 @@
 use std::io::{self, Read, Write};
+use std::default::Default;
 
 
+pub trait IoCtx {
+    fn read_input(&mut self, buf: &mut [u8]) -> io::Result<usize>;
+    fn write_input(&mut self, buf: &[u8]) -> io::Result<usize> {
+        panic!("`write_input` unsupported for `StdIoCtx`");
+    }
+    fn write_output(&mut self, buf: &[u8]) -> io::Result<usize>;
+    fn read_output(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        panic!("`read_output` unsupported for `StdIoCtx`");
+    }
+    fn flush_output(&mut self) -> io::Result<()>;
+}
 
-pub trait RW: Read + Write {}
-impl<T> RW for T where T: Read + Write {}
+// This workaround type wrapper for a generic T is directly in response to the error message:
+// = note: only traits defined in the current crate can be implemented for a type parameter
+// Solution taken from the error index: https://doc.rust-lang.org/error-index.html#E0210
+// struct IoCtxType<T>(T);
 
+impl Read for dyn IoCtx {
+// impl<T> Read for IoCtxType<T> where T: IoCtx {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.read_input(buf)
+    }
+}
+
+impl Write for dyn IoCtx {
+// impl<T> Write for IoCtxType<T> where T: IoCtx {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.write_output(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.flush_output()
+    }
+}
 
 
 /// Basic context using stdin and stdout impls for Read, Write
-pub struct StdIOContext {
+pub struct StdIoCtx {
     input: io::Stdin,
     output: io::Stdout,  // bf does not support stderr
 }
 
-impl StdIOContext {
-    pub fn new() -> Self {
+impl Default for StdIoCtx {
+    fn default() -> Self {
         Self {
             input: io::stdin(),
             output: io::stdout(),
@@ -22,119 +53,57 @@ impl StdIOContext {
     }
 }
 
-impl Read for StdIOContext {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        /*
-        let mut buf_string: String = String::new();
-        let result = self.input.read_line(&mut buf_string);
-        buf[..buf_string.len()].clone_from_slice(buf_string.as_bytes());
-        result
-        */
-        self.input.read(buf)
-    }
+impl IoCtx for StdIoCtx {
+    fn read_input(&mut self, buf: &mut [u8]) -> io::Result<usize> { self.input.read(buf) }
+    fn write_output(&mut self, buf: &[u8]) -> io::Result<usize> { self.output.write(buf) }
+    fn flush_output(&mut self) -> io::Result<()> { self.output.flush() }
 }
-
-impl Write for StdIOContext {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.output.write(buf)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.output.flush()
-    }
-}
-
 
 
 /// Struct wrapper for u8 vector implementing Read, Write traits
-pub struct ByteBuf {
-    pub buf: Vec<u8>,
+struct ByteBuf {
+    buf: Vec<u8>,
+}
+
+impl Default for ByteBuf {
+    fn default() -> Self { Self { buf: Vec::new() } }
 }
 
 impl Read for ByteBuf {
     fn read(&mut self, input_buf: &mut [u8]) -> io::Result<usize> {
         // slice of input buffer for which Read is implemented
         let n_read = (&self.buf[..]).read(input_buf)?;
-        // we are not worried about underflow here because we trust the impl of Read used above
-        self.buf.truncate(self.buf.len() - n_read);
+        self.buf.drain(..n_read);
         io::Result::Ok(n_read)
     }
 }
 
 impl Write for ByteBuf {
-    fn write(&mut self, output_buf: &[u8]) -> io::Result<usize> {
-        self.buf.write(output_buf)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.buf.flush()
-    }
+    fn write(&mut self, output_buf: &[u8]) -> io::Result<usize> { self.buf.write(output_buf) }
+    fn flush(&mut self) -> io::Result<()> { self.buf.flush() }
 }
-
-
-
-pub struct StdUTF8IOContext {
-    input: io::Stdin,
-    output: ByteBuf,
-}
-
-impl StdUTF8IOContext {
-    pub fn new() -> Self {
-        Self {
-            input: io::stdin(),
-            output: ByteBuf { buf: Vec::new() },
-        }
-    }
-}
-
-impl Read for StdUTF8IOContext {
-    // TODO: how to not copypasta this from StdIOContext?
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.input.read(buf)
-    }
-}
-
-impl Write for StdUTF8IOContext {
-    fn write(&mut self, output_buf: &[u8]) -> io::Result<usize> {
-        // TODO: print utf8-encoded chars to stdout
-        self.output.write(output_buf)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.output.flush()
-    }
-}
-
 
 
 /// IOContext supporting reading from input buffer, writing to output buffer, both of which
 /// individually support both Read, Write or use in testing or other non-production environments
-pub struct MockIOContext {
-    pub input: ByteBuf,
-    pub output: ByteBuf,
+pub struct MockIoCtx {
+    input: ByteBuf,
+    output: ByteBuf,
 }
 
-impl MockIOContext {
-    pub fn new() -> Self {
-        MockIOContext {
-            input: ByteBuf { buf: Vec::new() },
-            output: ByteBuf { buf: Vec::new() },
+impl Default for MockIoCtx {
+    fn default() -> Self {
+        Self {
+            input: ByteBuf::default(),
+            output: ByteBuf::default(),
         }
     }
 }
 
-impl Read for MockIOContext {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.input.read(buf)
-    }
-}
-
-impl Write for MockIOContext {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.output.write(buf)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.output.flush()
-    }
+impl IoCtx for MockIoCtx {
+    fn read_input(&mut self, buf: &mut [u8]) -> io::Result<usize> { self.input.read(buf) }
+    fn write_input(&mut self, buf: &[u8]) -> io::Result<usize> { self.input.write(buf) }
+    fn write_output(&mut self, buf: &[u8]) -> io::Result<usize> { self.output.write(buf) }
+    fn read_output(&mut self, buf: &mut [u8]) -> io::Result<usize> { self.output.read(buf) }
+    fn flush_output(&mut self) -> io::Result<()> { self.output.flush() }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 extern crate clap;
 
+use std::cell::RefCell;
+
 use clap::{App, Arg, ArgMatches};
 
 mod ioctx;
@@ -71,10 +73,14 @@ fn main() {
         _ => panic!("bfi: argument error"),
     };
 
-    let io_context = get_io_context(opts.is_present(UTF8_FLAG), opts.is_present(UNBUFFERED_FLAG));
+    let io_context = RefCell::new(
+        get_io_context(opts.is_present(UTF8_FLAG), opts.is_present(UNBUFFERED_FLAG)));
 
     let execution_status: interpreter::ExecutionStatus<String> =
-        interpreter::ExecutionContext::new(io_context, program_string.as_str()).execute();
+        interpreter::ExecutionContext::new(
+            io_context.borrow_mut(),
+            program_string.as_str(),
+        ).execute();
 
     let retcode: i32 = match execution_status {
         interpreter::ExecutionStatus::Terminated => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,11 +47,12 @@ fn get_command_line_args() -> ArgMatches<'static> {
         .get_matches()
 }
 
-fn get_io_context(use_utf8: bool, use_unbuffered: bool) -> Box<dyn ioctx::RW> {
+fn get_io_context(use_utf8: bool, use_unbuffered: bool) -> Box<dyn ioctx::IoCtx> {
     match (use_utf8, use_unbuffered) {
-        (true, _) => Box::new(ioctx::StdUTF8IOContext::new()),
-        (_, true) => Box::new(ioctx::StdIOContext::new()), // ioctx::StdUnbufferedIOContext::new(),
-        _ => Box::new(ioctx::StdIOContext::new()),
+        // TODO: address
+        // (true, _) => Box::new(ioctx::StdUTF8IOContext::default()),
+        // (_, true) => Box::new(ioctx::StdIOContext::default()),
+        _ => Box::new(ioctx::StdIoCtx::default()),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,11 +15,9 @@ use interpreter::{ExecutionStatus, ExecutionContext};
 static PROGRAM_ARG: &str = "program";
 static VERBOSE_ARG: &str = "verbose";
 static FILE_ARG: &str = "file";
-static UTF8_FLAG: &str = "utf8";
 static UNBUFFERED_FLAG: &str = "unbuffered";
 
 
-// explicitly specify 'static lifetime
 fn get_command_line_args() -> ArgMatches<'static> {
     App::new("bfi")
         .version("0.1")
@@ -39,25 +37,19 @@ fn get_command_line_args() -> ArgMatches<'static> {
             .value_name("FILE")
             .conflicts_with(PROGRAM_ARG)
             .help("Program file to execute"))
-        .arg(Arg::with_name(UTF8_FLAG)
-            .short("u")
-            .long("utf8")
-            .takes_value(false)
-            .help("Use 8-bit Unicode output encoding"))
         .arg(Arg::with_name(UNBUFFERED_FLAG)
             .long("unbuffered")
             .takes_value(false)
-            .help("Do not buffer output"))
+            .help("Do not buffer output (note: may break output character encoding)"))
         .get_matches()
 }
 
 
-fn get_io_context(use_utf8: bool, use_unbuffered: bool) -> Box<dyn ioctx::IoCtx> {
-    match (use_utf8, use_unbuffered) {
-        // TODO: address
-        // (true, _) => Box::new(ioctx::StdUTF8IOContext::default()),
-        // (_, true) => Box::new(ioctx::StdIOContext::default()),
-        _ => Box::new(ioctx::StdIoCtx::default()),
+fn get_io_context(unbuffered: bool) -> Box<dyn ioctx::IoCtx> {
+    if unbuffered {
+        Box::new(ioctx::UnbufferedStdIoCtx::default())
+    } else {
+        Box::new(ioctx::StdIoCtx::default())
     }
 }
 
@@ -83,8 +75,7 @@ fn main() {
     // Creating the io_context inside a block like this ensures that it is dropped before the call
     // to std::process::exit, necessary to flush output buffer for stdout
     let retcode: i32 = {
-        let io_context = RefCell::new(
-            get_io_context(opts.is_present(UTF8_FLAG), opts.is_present(UNBUFFERED_FLAG)));
+        let io_context = RefCell::new(get_io_context(opts.is_present(UNBUFFERED_FLAG)));
 
         let execution_status: ExecutionStatus<String> =
             ExecutionContext::new(io_context.borrow_mut(), program_string.as_str()).execute();

--- a/tests/executable.rs
+++ b/tests/executable.rs
@@ -140,28 +140,25 @@ fn test_cat() {
         .execute();
 }
 
-// TODO: reimplement unicode support
 #[test]
-#[ignore]
-fn test_cat_unicode() {
+fn test_cat_unicode_unbuffered() {
     let unicode_str: &str = "😸\n";
     TestCase::new()
-        .with_arg("--utf8")
+        .with_arg("--unbuffered")
         .with_arg(",[.[-],]")
         .with_input(unicode_str)
         .expect_stdout(unicode_str)
         .execute();
 }
 
-// TODO: reimplement unicode support
 #[test]
-#[ignore]
-fn test_cat_unicode_mangled() {
+fn test_cat_unicode() {
     let unicode_str: &str = "😸\n";
     TestCase::new()
         .with_arg(",[.[-],]")
         .with_input(unicode_str)
-        .expect_stdout("\u{f0}\u{9f}\u{98}\u{b8}\n")  // mangled cat when each byte is ASCII decoded
+        .expect_stdout(unicode_str)
+        // .expect_stdout("\u{f0}\u{9f}\u{98}\u{b8}\n")  // when each byte is ASCII decoded
         .expect_retcode(0)
         .execute();
 }


### PR DESCRIPTION
At long last, this PR introduces an I/O context pattern that actually works for the primary use cases running as a binary, as a library, and in a testing environment.

The previous approach of holding a trait object but secretly hoping to access an implementation's fields directly (or access methods on that implementation not defined in the trait object) was never correct. A long goose chase involving downcasting, all sorts of smart pointers, and various failed implementations later, [this StackOverflow answer](https://stackoverflow.com/a/47642317/12322069) made it clear that what I was attempting to do was not how programs should be structured.

Instead, here the `ExecutionContext` holds a `RefMut` to the boxed trait object `IoCtx` that implements all of the necessary functions, including read and write from both the input and output streams. The `ExecutionContext` holds just this reference (and is thus `'a` lifetime parameterized) such that the `IoCtx` can be used after execution or reused multiple times — in the struct definition, `Option<RefMut<'a, Box<dyn IoCtx>>>`.
- `Option` is used such that the default `ExecutionContext` can be instantiated without an attached `IoCtx`
- `RefMut` allows the `IoCtx` to be mutably lent to the `ExecutionContext` for its lifetime and reused later
- `Box` is used to push the `dyn IoCtx` onto the heap, enabling different implementations of this trait of arbitrary size

Also:
- Explicit UTF8 support has been removed, YOYO if you want to use unicode (but in general it behaves as expected, and there are a number of passing tests with unicode)
- Unbuffered output has been reintroduced
- Implement the first "end-to-end" testing in `integration.rs` without directly using the executable through the use of `InMemoryIoCtx` reading input and storing output in accessible `Vec<u8>`s