### PR TITLE
Add lib.rs exposing interpreter functionality to other Rust programs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,13 @@ version = "0.1.0"
 authors = ["Gordon Hart <gordon.hart2@gmail.com>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+name = "bfi"
+path = "src/lib.rs"
+
+[[bin]]
+name = "bfi"
+path = "src/bin/main.rs"
 
 [dependencies]
 clap = "2.33.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [lib]
 name = "bfi"
 path = "src/lib.rs"
+crate-type = ["rlib", "dylib"]
 
 [[bin]]
 name = "bfi"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -4,12 +4,8 @@ use std::cell::RefCell;
 
 use clap::{App, Arg, ArgMatches};
 
-mod ioctx;
-mod interpreter;
-mod repl;
-mod token;
-
-use interpreter::{ExecutionStatus, ExecutionContext};
+use bfi::ioctx::{IoCtx, StdIoCtx, UnbufferedStdIoCtx};
+use bfi::interpreter::{ExecutionStatus, ExecutionContext};
 
 
 static PROGRAM_ARG: &str = "program";
@@ -45,11 +41,11 @@ fn get_command_line_args() -> ArgMatches<'static> {
 }
 
 
-fn get_io_context(unbuffered: bool) -> Box<dyn ioctx::IoCtx> {
+fn get_io_context(unbuffered: bool) -> Box<dyn IoCtx> {
     if unbuffered {
-        Box::new(ioctx::UnbufferedStdIoCtx::default())
+        Box::new(UnbufferedStdIoCtx::default())
     } else {
-        Box::new(ioctx::StdIoCtx::default())
+        Box::new(StdIoCtx::default())
     }
 }
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -251,4 +251,25 @@ mod test {
         assert_eq!(val, &buf);
         assert_eq!(status, ExecutionStatus::<String>::Terminated);
     }
+
+    #[test]
+    fn test_missing_close_bracket() {
+        for token in vec![Token::LoopBeg, Token::LoopEnd] {
+            let mut ectx = ExecutionContext::default();
+            ectx.program = vec![token];
+            let status = ectx.execute();
+            match status {
+                ExecutionStatus::ProgramError(_) => {},
+                _ => panic!(),
+            };
+        };
+    }
+
+    #[test]
+    fn test_debug_fmt() {
+        let mut ectx = ExecutionContext::default();
+        ectx.program = vec![Token::DebugDump];
+        let status = ectx.execute();
+        assert_eq!(status, ExecutionStatus::<String>::Terminated);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,11 @@
+pub mod ioctx;
+pub mod interpreter;
+pub mod token;
+pub mod repl;
+
+use interpreter::{ExecutionStatus, ExecutionContext};
+
+
+pub fn test() {
+    println!("something!");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,8 @@ pub enum Error<T> {
 }
 
 
-pub fn bf_execute(program: &str, input: &[u8]) -> Result<Vec<u8>, Error<String>> {
+#[no_mangle]
+pub extern fn bf_execute(program: &str, input: &[u8]) -> Result<Vec<u8>, Error<String>> {
     let ictx = RefCell::new(Box::new(InMemoryIoCtx::default()) as Box<dyn IoCtx>);
     let mut ictx_ref = ictx.borrow_mut();
     if let Err(_) = ictx_ref.write_input(&input[..]) {
@@ -47,7 +48,7 @@ pub fn bf_execute(program: &str, input: &[u8]) -> Result<Vec<u8>, Error<String>>
 
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::*;
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,60 @@
+use std::cell::RefCell;
+
 pub mod ioctx;
 pub mod interpreter;
 pub mod token;
 pub mod repl;
 
-use ioctx::InMemoryIoCtx;
+use ioctx::{IoCtx, InMemoryIoCtx};
 use interpreter::{ExecutionStatus, ExecutionContext};
 
 
-pub fn test() {
-    println!("something!");
+#[derive(Debug)]
+pub enum Error<T> {
+    ProgramError(T),
+    InternalError(T),
+}
+
+
+pub fn bf_execute(program: &str, input: &[u8]) -> Result<Vec<u8>, Error<String>> {
+    let ictx = RefCell::new(Box::new(InMemoryIoCtx::default()) as Box<dyn IoCtx>);
+    let mut ictx_ref = ictx.borrow_mut();
+    if let Err(_) = ictx_ref.write_input(&input[..]) {
+        return Err(Error::InternalError("unable to open buffer".to_string()));
+    };
+    let status = ExecutionContext::new(ictx_ref, program).execute();
+    let mut ictx_ref = ictx.borrow_mut();
+    match status {
+        ExecutionStatus::Terminated => {
+            let mut output: Vec<u8> = Vec::new();
+            let mut buf: [u8; 256] = [0; 256];
+            loop {
+                match ictx_ref.read_output(&mut buf) {
+                    Ok(n) => {
+                        if n == 0 { break };
+                        output.extend_from_slice(&buf[..n]);
+                    },
+                    Err(_) => break,
+                };
+            };
+            Ok(output)
+        },
+        ExecutionStatus::ProgramError(e) => Err(Error::ProgramError(e)),
+        ExecutionStatus::InternalError(e) => Err(Error::InternalError(e)),
+        _ => Err(Error::InternalError("unknown error occurred".to_string())),
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_addition() {
+        let program: &str = ",>,<[->+<]>.";
+        let input: Vec<u8> = vec![3, 4];
+        let output: Vec<u8> = bf_execute(program, &input[..]).unwrap();
+        assert_eq!(output, vec![7]);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod interpreter;
 pub mod token;
 pub mod repl;
 
+use ioctx::InMemoryIoCtx;
 use interpreter::{ExecutionStatus, ExecutionContext};
 
 


### PR DESCRIPTION
This PR introduces `lib.rs` with the externally-visible `bf_execute` function allowing other Rust code to import `extern crate bfi` and call the interpreter with a program, its input, and receive its output in a `Result<Vec<u8>, bfi::Error<String>>`.