### PR TITLE
ZMQ REQ/REP server example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ addons:
       - gcc
       - binutils-dev
       - libiberty-dev
+      - libzmq3-dev
 
 after_success: |
   wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ path = "src/bin/main.rs"
 clap = "2.33.0"
 libc = "0.2.66"
 rustyline = "5.0.4"
+
+[dev-dependencies]
+zmq = "0.9.2"

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,0 +1,28 @@
+extern crate clap;
+extern crate zmq;
+
+use clap::{App, Arg};
+
+// client to the example server, usage:
+// `$ cargo run --example client 10 12`
+fn main() -> Result<(), zmq::Error> {
+    let args = App::new("a + b")
+        .arg(Arg::with_name("a").index(1).required(true))
+        .arg(Arg::with_name("b").index(2).required(true))
+        .get_matches();
+
+    let ctx = zmq::Context::new();
+    let socket = ctx.socket(zmq::REQ)?;
+    socket.connect("tcp://127.0.0.1:12345")?;
+
+    let a: u8 = args.value_of("a").unwrap().parse::<u8>().unwrap();
+    let b: u8 = args.value_of("b").unwrap().parse::<u8>().unwrap();
+    let input = vec![a, b];
+    socket.send(input, 0i32)?;
+
+    let mut result_buffer = [0u8; 1];
+    socket.recv_into(&mut result_buffer, 0i32)?;
+    println!("{} + {} = {}", a, b, result_buffer[0]);
+
+    Ok(())
+}

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -15,8 +15,8 @@ fn main() -> Result<(), zmq::Error> {
     let socket = ctx.socket(zmq::REQ)?;
     socket.connect("tcp://127.0.0.1:12345")?;
 
-    let a: u8 = args.value_of("a").unwrap().parse::<u8>().unwrap();
-    let b: u8 = args.value_of("b").unwrap().parse::<u8>().unwrap();
+    let a: u8 = args.value_of("a").unwrap().parse().expect("arg \"a\" error");
+    let b: u8 = args.value_of("b").unwrap().parse().expect("arg \"b\" error");
     let input = vec![a, b];
     socket.send(input, 0i32)?;
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,0 +1,90 @@
+extern crate bfi;
+extern crate zmq;
+
+use std::io::Write;
+use std::cell::RefCell;
+use std::io;
+
+use bfi::{ioctx, interpreter};
+
+struct ServerIoCtx {
+    ctx: zmq::Context,
+    socket: zmq::Socket,
+    input_buffer: Vec<u8>,
+    readable: bool,
+}
+
+impl ioctx::IoCtx for ServerIoCtx {
+    fn read_input(&mut self, mut buf: &mut [u8]) -> Result<usize, io::Error> {
+        let flags = 0i32;
+        if self.input_buffer.len() == 0 {
+            if !self.readable {
+                // TODO: better error
+                return Err(io::Error::new(io::ErrorKind::Other, "not readable"))
+            } else {
+                match self.socket.recv_bytes(flags) {
+                    Ok(bytes_received) => {
+                        buf[0] = *bytes_received.iter().next().unwrap();
+                        self.input_buffer.extend_from_slice(&bytes_received[1..]);
+                        println!("received {} bytes", bytes_received.len());
+                        self.readable = false;
+                        Ok(1)
+                    }
+                    Err(_) => {
+                        println!("unable to read input");
+                        Err(io::Error::new(io::ErrorKind::Other, "unable to read"))
+                    }
+                }
+            }
+        } else {
+            buf.write(&self.input_buffer[..1])?;
+            self.input_buffer.remove(0);
+            Ok(1)
+        }
+    }
+
+    fn write_output(&mut self, buf: &[u8]) -> Result<usize, io::Error> {
+        let flags = 0i32;
+        if self.readable {
+            return Err(io::Error::new(io::ErrorKind::Other, "toggled to read, can't send"));
+        };
+        match self.socket.send(buf, flags) {
+            Ok(_) => {
+                println!("sent {} bytes", buf.len());
+                self.readable = true;
+                Ok(buf.len())
+            },
+            Err(_) => {
+                println!("unable to write output");
+                Err(io::Error::new(io::ErrorKind::Other, "unable to send"))
+            }
+        }
+    }
+
+    fn flush_output(&mut self) -> Result<(), io::Error> {
+        Ok(())
+    }
+}
+
+impl ServerIoCtx {
+    fn new(protocol: &str, address: &str, port: u32) -> Self {
+        let ctx = zmq::Context::new();
+        let socket = ctx.socket(zmq::REP).unwrap();
+        let address: String = format!("{}://{}:{}", protocol, address, port);
+        socket.bind(address.as_str()).unwrap();
+        Self {
+            ctx: ctx,
+            socket: socket,
+            input_buffer: Vec::new(),
+            readable: true,
+        }
+    }
+}
+
+fn main() {
+    let adder: &str = "+[-,>,<[->+<]>.[-]<+]";
+    let ictx = ServerIoCtx::new("tcp", "127.0.0.1", 12345u32);
+    let ictx_rc = RefCell::new(Box::new(ictx) as Box<dyn ioctx::IoCtx>);
+    let status = interpreter::ExecutionContext::new(ictx_rc.borrow_mut(), adder).execute();
+    println!("exit status: {:?}", status);
+}

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -3,87 +3,103 @@ extern crate zmq;
 
 use std::io::Write;
 use std::cell::RefCell;
-use std::io;
+use std::io::{self, Error, ErrorKind};
 
 use bfi::{ioctx, interpreter};
 
-struct ServerIoCtx {
-    ctx: zmq::Context,
+#[derive(Debug)]
+enum SocketStatus {
+    Readable,
+    Writable,
+}
+
+struct ZmqRepServerIoCtx {
     socket: zmq::Socket,
     input_buffer: Vec<u8>,
-    readable: bool,
+    status: SocketStatus, // REQ/REP pair is strictly alternating
 }
 
-impl ioctx::IoCtx for ServerIoCtx {
-    fn read_input(&mut self, mut buf: &mut [u8]) -> Result<usize, io::Error> {
-        let flags = 0i32;
-        if self.input_buffer.len() == 0 {
-            if !self.readable {
-                // TODO: better error
-                return Err(io::Error::new(io::ErrorKind::Other, "not readable"))
-            } else {
-                match self.socket.recv_bytes(flags) {
-                    Ok(bytes_received) => {
-                        buf[0] = *bytes_received.iter().next().unwrap();
-                        self.input_buffer.extend_from_slice(&bytes_received[1..]);
-                        println!("received {} bytes", bytes_received.len());
-                        self.readable = false;
-                        Ok(1)
-                    }
-                    Err(_) => {
-                        println!("unable to read input");
-                        Err(io::Error::new(io::ErrorKind::Other, "unable to read"))
-                    }
-                }
-            }
-        } else {
-            buf.write(&self.input_buffer[..1])?;
-            self.input_buffer.remove(0);
-            Ok(1)
-        }
-    }
-
-    fn write_output(&mut self, buf: &[u8]) -> Result<usize, io::Error> {
-        let flags = 0i32;
-        if self.readable {
-            return Err(io::Error::new(io::ErrorKind::Other, "toggled to read, can't send"));
-        };
-        match self.socket.send(buf, flags) {
-            Ok(_) => {
-                println!("sent {} bytes", buf.len());
-                self.readable = true;
-                Ok(buf.len())
-            },
-            Err(_) => {
-                println!("unable to write output");
-                Err(io::Error::new(io::ErrorKind::Other, "unable to send"))
-            }
-        }
-    }
-
-    fn flush_output(&mut self) -> Result<(), io::Error> {
-        Ok(())
-    }
-}
-
-impl ServerIoCtx {
+impl ZmqRepServerIoCtx {
     fn new(protocol: &str, address: &str, port: u32) -> Self {
         let ctx = zmq::Context::new();
         let socket = ctx.socket(zmq::REP).unwrap();
         let address: String = format!("{}://{}:{}", protocol, address, port);
         socket.bind(address.as_str()).unwrap();
         Self {
-            ctx: ctx,
             socket: socket,
             input_buffer: Vec::new(),
-            readable: true,
+            status: SocketStatus::Readable,
         }
     }
 }
 
+impl ioctx::IoCtx for ZmqRepServerIoCtx {
+    fn read_input(&mut self, mut buf: &mut [u8]) -> Result<usize, Error> {
+        let flags = 0i32;
+        match (self.input_buffer.len(), &self.status) {
+            // ran out of input bytes, which is a caller problem
+            (0, SocketStatus::Writable) => {
+                // can't do anything, caller needs to send two bytes next time
+                Ok(0)
+            },
+            // dig into our store of previously received bytes that have yet to be consumed
+            (_, SocketStatus::Writable) => {
+                buf.write(&self.input_buffer[..1])?;
+                self.input_buffer.remove(0);
+                Ok(1)
+            },
+            (_, SocketStatus::Readable) => {
+                match self.socket.recv_bytes(flags) {
+                    // empty packet received, report zero bytes read and have faith that this is
+                    // handled properly by the bf program (it is)
+                    Ok(v) if v.len() == 0 => {
+                        self.status = SocketStatus::Writable;
+                        Ok(0)
+                    },
+                    // write the first byte to the buffer, store the rest for later access
+                    Ok(bytes_received) => {
+                        buf.write(&bytes_received[..1])?;
+                        self.input_buffer.extend_from_slice(&bytes_received[1..]);
+                        self.status = SocketStatus::Writable;
+                        Ok(1)
+                    }
+                    // bad news if we reach here
+                    Err(e) => Err(Error::new(ErrorKind::Other, format!("{:?}", e))),
+                }
+            },
+        }
+    }
+
+    fn write_output(&mut self, buf: &[u8]) -> Result<usize, io::Error> {
+        let flags = 0i32;
+        match &self.status {
+            SocketStatus::Writable => {
+                match self.socket.send(buf, flags) {
+                    Ok(()) => {
+                        self.status = SocketStatus::Readable;
+                        // any input left is garbage extra input from the caller
+                        self.input_buffer.clear();
+                        Ok(buf.len())
+                    },
+                    // fatal
+                    Err(e) => Err(io::Error::new(io::ErrorKind::Other, format!("{:?}", e))),
+                }
+            },
+            // shouldn't occur due to the simplicity of the bf program and protections in read_input
+            SocketStatus::Readable => Err(Error::new(ErrorKind::Other, "unable to write")),
+        }
+    }
+
+    fn flush_output(&mut self) -> Result<(), io::Error> {
+        // has no meaning with ZMQ sockets
+        Ok(())
+    }
+}
+
 fn main() {
+    // reads two input bytes and returns their wrapped sum, nonterminating
     let adder: &str = "+[-,>,<[->+<]>.[-]<+]";
-    let ictx = ServerIoCtx::new("tcp", "127.0.0.1", 12345u32);
+    let ictx = ZmqRepServerIoCtx::new("tcp", "127.0.0.1", 12345u32);
     let ictx_rc = RefCell::new(Box::new(ictx) as Box<dyn ioctx::IoCtx>);
     let status = interpreter::ExecutionContext::new(ictx_rc.borrow_mut(), adder).execute();
     println!("exit status: {:?}", status);

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -82,11 +82,11 @@ fn main() {
                     eprintln!("bfi: terminated without errors");
                 };
                 0
-            }
-            ExecutionStatus::ProgramError(err) => {
+            },
+            ExecutionStatus::ProgramError(err) | ExecutionStatus::InternalError(err) => {
                 eprintln!("bfi: exited with error: {}", err);
                 1
-            }
+            },
             _ => panic!("bfi: internal error"),
         }
     };


### PR DESCRIPTION
This PR includes a new example in `examples/{client,server}.rs` demonstrating a custom `IoCtx` implementation utilizing ZMQ REQ/REP sockets to create a networked microservice whose control flow and workload are handled by a BF program.