### PR TITLE
Refine README, some minor stylistic modifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ analysis to the machines like [GPT-2](https://github.com/openai/gpt-2) that are
 good at them and focus only on stuff you, as a human, are naturally good at:
 pointer arithmetic, rigid control flow, and data encoding.
 
+You know that feeling of dejection when you go to learn a new language and see
+that it has an [entire book](https://doc.rust-lang.org/book/) written about it,
+an [estranged sequel](https://doc.rust-lang.org/nomicon/) whose existence is
+denied by most, and even some
+[aspirational fanfiction](https://rust-lang.github.io/async-book/01_getting_started/01_chapter.html)
+in the works? Don't you just wish everything you needed to know about your new
+language fit in a single README section? Bear with me here for a little longer.
+
 Imagine you're back on the primordial savannah but instead of a spear in your
 hand it's a pointer and instead of lush grassland around you it's a single
 dimensional roll of tape extending forever off into the point horizon. If you
@@ -48,6 +56,10 @@ Plus two more `bfi` extension commands:
 | ------- | ----------- |
 | `#` | Dump program internals to `stderr` |
 | `%` | Enter into a REPL |
+
+Every other character is a comment. Feel free to annotate your code with as many
+emoji as you think are reasonable for an adult to put into a text file and use
+whatever limp or virile indentation strategy floats your boat.
 
 
 ## An Example
@@ -84,10 +96,26 @@ implmentation:
 - The roll of tape is infinite in both directions. You are free to travel along
   it as you wish and fresh cells will be allocated ahead of you until your OS
   decides otherwise.
-- Cells hold a single byte (i.e. value on [0, 255]), are initialized to zero,
+- Cells hold a single byte (i.e. value on `[0, 255]`), are initialized to zero,
   and wrap on over or underflow.
 - If input is requested (`,`) when none is available the interpreter will move
   on without action.
+
+
+## Usage
+
+Compile `bfi` as you would any other Rust project not provided prepacked through
+standard channels:
+
+```
+$ cargo build --release
+```
+
+From there, figure it out:
+
+```
+$ ./bfi --help
+```
 
 
 ## `bfi` as a Library
@@ -97,7 +125,7 @@ Luckily for you Rust programmers, `bfi` has a library interface! See
 
 BrainF\*ck is an excellent language to implement the workload of your networked
 application in. See `examples/{server,client}.rs` for a simple number cruncher
-microservice and client communicating using
+microservice and example client communicating using
 [ZeroMQ](https://zeromq.org/socket-api/).
 
 ### Foreign Usage
@@ -125,34 +153,3 @@ Serious face: the secondary purpose of this project is the interpreter; its
 primary purpose is as a playground to learn Rust. It's my first stab at the
 language and its ecosystem and it's probably not the highest quality or most
 idiomatic codebase out there. Take what you see here with a grain of salt.
-
-
-## Objectives
-
-- Idiomatic Rust language usage
-- Correct BF implementation
-- Standard command line niceties:
-    - Option to run program from argument
-    - Option to run program from file
-    - Read program input from stdin
-    - Proper exit code setting
-    - Expected options like `--help`
-    - Expected behavior on SIGINT, EOF, SIGTERM, etc.
-- Reasonable performance and resource usage (nothing dumb)
-- Reasonable usage of `panic!` (and things that cause it, like `unwrap`)
-- Non-negligible test coverage
-- No compiler warnings
-- No [clippy](https://github.com/rust-lang/rust-clippy) warnings
-
-
-## TODOs
-
-- [x] Accept and ignore non-command characters instead of failing (comments)
-- [x] Integrate `readline` for REPL input
-- [x] Write docstrings
-- [x] Support running from file with `-f` and `--filename`
-- [x] Add `-h`/`--help` usage flag
-- [x] Add `-v`/`--verbose` flag to print extra information (like exit message)
-- [x] Implement close-to-full test coverage
-- [x] Apply `rustfmt` formatting
-- [x] Document all `panic!` cases with a `# Panics` docstring section

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Plus two more `bfi` extension commands:
 | `%` | Enter into a REPL |
 
 
-## Example
+## An Example
 
 Now that you have the language down pat we can jog our legs with a gumball
 program:
@@ -71,23 +71,37 @@ Example usage:
 $ <README.md bfi ',[.[-],]'
 ```
 
-Yes, GNU `cat` supports interior NUL bytes and this program does not. Go away.
+Yes, GNU `cat` supports interior NUL bytes and this program does not. Those
+invalid unicode bytes in that binary you accidentally catted would have messed
+up your terminal's encoding anyway.
 
 
-# `bfi` as a Library
+## The Details
+
+To clear up some of the ambiguity around the behavior of this BrainF\*ck
+implmentation:
+
+- The roll of tape is infinite in both directions. You are free to travel along
+  it as you wish and fresh cells will be allocated ahead of you until your OS
+  decides otherwise.
+- Cells hold a single byte (i.e. value on [0, 255]), are initialized to zero,
+  and wrap on over or underflow.
+- If input is requested (`,`) when none is available the interpreter will move
+  on without action.
+
+
+## `bfi` as a Library
 
 Luckily for you Rust programmers, `bfi` has a library interface! See
 `examples/toy.rs` for a starting point.
 
-## Foreign Usage
+### Foreign Usage
 
 Some hope remains for those of us forced to use a tired language like Python
-in our professionial environments. Check your despair at the gate, we're about
-to embark on a fantastical journey to the foreign land of `bfi` + FFI.
-
-Well, not so fantastical. You can work with `libbfi` the same way you'd
-incorporate any foreign object into your project. See
-`examples/python/bindings.py` for a Python integration using `ctypes`.
+in our professionial environments. Check your despair at the gate — you can work
+with `libbfi` the same way you'd incorporate any foreign object into your
+project. See `examples/python/bindings.py` for a Python integration using
+`ctypes`.
 
 Further, `examples/python/trick_your_boss.py` contains a minimal framework for
 surreptitiously programming in BrainF\*ck at work under your manager's nose.
@@ -102,8 +116,10 @@ depth or proprietary codecs or just let GPT-2 make your excuse up for you.
 ---
 
 
-Serious face this time: the secondary purpose of this project is the
-interpreter; its primary purpose is as a playground to learn Rust.
+Serious face: the secondary purpose of this project is the interpreter; its
+primary purpose is as a playground to learn Rust. It's my first stab at the
+language and its ecosystem and it's probably not the highest quality or most
+idiomatic codebase out there. Take what you see here with a grain of salt.
 
 
 ## Objectives

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ $ <README.md bfi ',[.[-],]'
 ```
 
 Yes, GNU `cat` supports interior NUL bytes and this program does not. Those
-invalid unicode bytes in that binary you accidentally catted would have messed
-up your terminal's encoding anyway.
+invalid unicode sequences in that binary you accidentally catted would only
+have messed up your terminal's encoding anyway.
 
 
 ## The Details
@@ -94,6 +94,11 @@ implmentation:
 
 Luckily for you Rust programmers, `bfi` has a library interface! See
 `examples/toy.rs` for a starting point.
+
+BrainF\*ck is an excellent language to implement the workload of your networked
+application in. See `examples/{server,client}.rs` for a simple number cruncher
+microservice and client communicating using
+[ZeroMQ](https://zeromq.org/socket-api/).
 
 ### Foreign Usage
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -19,7 +19,7 @@ fn get_command_line_args() -> ArgMatches<'static> {
         .version("0.1")
         .about("BrainF*ck language interpreter")
         .arg(Arg::with_name(PROGRAM_ARG)
-            .help("Program to execute")
+            .help("Program to execute, or launch interactive session if no prorgram is provided")
             .conflicts_with(FILE_ARG)
             .index(1))
         .arg(Arg::with_name(VERBOSE_ARG)

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -65,7 +65,7 @@ fn main() {
         // default to REPL if no program provided
         (None, None) => "!".to_string(),
         // final arm should never be reached due to mutual `conflicts_with`
-        _ => panic!("bfi: argument error"),
+        _ => unreachable!(),
     };
 
     // Creating the io_context inside a block like this ensures that it is dropped before the call

--- a/src/ioctx.rs
+++ b/src/ioctx.rs
@@ -104,10 +104,8 @@ impl IoCtx for UnbufferedStdIoCtx {
     fn read_input(&mut self, buf: &mut [u8]) -> io::Result<usize> { self.ctx.input.read(buf) }
     fn write_output(&mut self, buf: &[u8]) -> io::Result<usize> {
         let result = self.ctx.output.write(buf)?;
-        match self.flush_output() {
-            Ok(_) => Ok(result),
-            Err(e) => Err(e),
-        }
+        self.flush_output()?;
+        Ok(result)
     }
     fn flush_output(&mut self) -> io::Result<()> { self.ctx.output.flush() }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -97,6 +97,15 @@ mod test {
     }
 
     #[test]
+    fn decoding_comments() {
+        let program: &str = "0>something <+\t-.else,[]#\nentirely 💁%";
+        let program_decoded: Vec<Token> = Token::parse_str(program);
+        for (&c, &t) in program_decoded.iter().zip(TOKENS.into_iter()) {
+            assert_eq!(c, t);
+        }
+    }
+
+    #[test]
     fn encoding() {
         for (c, &t) in SYMBOLS.chars().zip(TOKENS.into_iter()) {
             assert_eq!(Token::encode(t), c);


### PR DESCRIPTION
This small PR touches up the README by removing the last of the development notes and tweaks the code in a few small places, including the usage of the `unreachable!` macro where necessary and adding a unit test covering token parsing.